### PR TITLE
Document SG_DATA_DIR data provenance and no-CSV-port policy (#14)

### DIFF
--- a/docs/smart_grid_data_provenance.md
+++ b/docs/smart_grid_data_provenance.md
@@ -52,10 +52,11 @@ fault-table boundaries used for DGA classification are encoded in
 The team repo's processed CSVs (under `data/processed/`) are **not** copied
 into this AOB fork or any upstream IBM PR. Reasons:
 
-1. **Licensing** — the five Kaggle source datasets used in the team's data
-   pipeline are CC0 individually, but the processed outputs are class-specific
-   derivatives. Keeping them out of AOB avoids a licensing audit for upstream
-   reviewers.
+1. **Licensing** — three of the five Kaggle source datasets are CC0; two
+   (Transformer Health Index — ODbL, and Current & Voltage Monitoring — author
+   copyright) have redistribution restrictions and are treated as local-only in
+   the team pipeline. No processed outputs derived from restricted sources are
+   ported to AOB, which avoids a licensing audit for upstream reviewers.
 2. **Reproducibility** — the synthetic data can be regenerated from
    `data/generate_synthetic.py` in the team repo. Any downstream user with the
    generator and the IEC encoding can produce equivalent datasets without
@@ -75,15 +76,15 @@ export SG_DATA_DIR=$(pwd)/data/processed
 
 ## Source datasets
 
-The team's data pipeline draws from five Kaggle CC0 datasets:
+The team's data pipeline draws from five Kaggle datasets; licensing varies:
 
-| Dataset | Domain servers |
-|---|---|
-| Power Transformers FDD & RUL | IoT, TSFM |
-| DGA Fault Classification | FMSR |
-| Smart Grid Fault Records | WO |
-| Transformer Health Index | FMSR (supplemental) |
-| Current & Voltage Monitoring | IoT, TSFM (supplemental) |
+| Dataset | License | Domain servers |
+|---|---|---|
+| Power Transformers FDD & RUL | CC0 | IoT, TSFM |
+| DGA Fault Classification | CC0 | FMSR |
+| Smart Grid Fault Records | CC0 | WO |
+| Transformer Health Index | ODbL (redistribution restricted; local-only) | FMSR (supplemental) |
+| Current & Voltage Monitoring | Author copyright (redistribution restricted; local-only) | IoT, TSFM (supplemental) |
 
 Dataset licensing details and row counts: `docs/hpml_datasets.pdf` in the team
 repo.

--- a/docs/smart_grid_data_provenance.md
+++ b/docs/smart_grid_data_provenance.md
@@ -1,0 +1,111 @@
+# Smart Grid Data Provenance
+
+*Created: 2026-05-01*
+*Owner: Tanisha Rathod (tannedpeach)*
+*Issue: [#14](https://github.com/HPML6998-S26-Team13/AssetOpsBench/issues/14)*
+
+## Overview
+
+The Smart Grid 7th-domain MCP servers in this fork operate over **synthetic
+data only**. No proprietary or class-licensed data is shipped with the AOB
+codebase. Runtime data location is configured via the `SG_DATA_DIR`
+environment variable.
+
+## What `SG_DATA_DIR` is
+
+`SG_DATA_DIR` is an environment variable pointing at the directory containing
+the synthetic Smart Grid CSV datasets the servers read at runtime.
+
+**Default path:** `./data/sg_processed/` relative to the current working
+directory (wherever the server process is launched from).
+
+Resolution order in [`src/servers/smart_grid/base.py`](../src/servers/smart_grid/base.py):
+
+1. `SG_DATA_DIR` environment variable — absolute or cwd-relative path.
+2. `./data/sg_processed/` relative to cwd (fallback if the variable is unset).
+
+The path is not required to exist at import time; existence is enforced on the
+first data-loading call, which raises a clear `FileNotFoundError` with
+remediation instructions if the path is missing.
+
+## What's in `SG_DATA_DIR`
+
+Six synthetic CSV files, one per logical data slice:
+
+| File | Server(s) | Description |
+|---|---|---|
+| `asset_metadata.csv` | IoT | Static nameplate data per transformer (ID, rating, criticality, install date) |
+| `sensor_readings.csv` | IoT, TSFM | Time-series sensor readings (load current, winding temp, oil temp, voltage) |
+| `failure_modes.csv` | FMSR | Failure mode catalogue with severity, IEC code, and recommended action |
+| `dga_records.csv` | FMSR | Dissolved Gas Analysis (DGA) records per transformer, per sample date |
+| `rul_labels.csv` | TSFM | Remaining-useful-life labels and health index per transformer |
+| `fault_records.csv` | WO | Historical fault and maintenance event records |
+
+All values are synthetic. Gas concentrations in `dga_records.csv` are
+calibrated against the IEC 60599:2022 Rogers Ratio fault-table boundaries
+encoded in
+[`data/knowledge/transformer_standards.json`](../../data/knowledge/transformer_standards.json)
+in the team repo, so `analyze_dga` tool outputs are internally consistent with
+the ground-truth labels.
+
+## No-CSV-port policy
+
+The team repo's processed CSVs (under `data/processed/`) are **not** copied
+into this AOB fork or any upstream IBM PR. Reasons:
+
+1. **Licensing** — the five Kaggle source datasets used in the team's data
+   pipeline are CC0 individually, but the processed outputs are class-specific
+   derivatives. Keeping them out of AOB avoids a licensing audit for upstream
+   reviewers.
+2. **Reproducibility** — the synthetic data can be regenerated from
+   `data/generate_synthetic.py` in the team repo. Any downstream user with the
+   generator and the IEC encoding can produce equivalent datasets without
+   needing the team's processed CSVs.
+3. **AOB cleanliness** — no raw class artifacts in the fork simplifies upstream
+   review scope.
+
+**For a reviewer or downstream user needing Smart Grid data:**
+
+```bash
+git clone https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp.git
+cd hpml-assetopsbench-smart-grid-mcp
+pip install -r requirements.txt
+python data/generate_synthetic.py          # produces data/processed/*.csv
+export SG_DATA_DIR=$(pwd)/data/processed
+```
+
+## Source datasets
+
+The team's data pipeline draws from five Kaggle CC0 datasets:
+
+| Dataset | Domain servers |
+|---|---|
+| Power Transformers FDD & RUL | IoT, TSFM |
+| DGA Fault Classification | FMSR |
+| Smart Grid Fault Records | WO |
+| Transformer Health Index | FMSR (supplemental) |
+| Current & Voltage Monitoring | IoT, TSFM (supplemental) |
+
+Dataset licensing details and row counts: `docs/hpml_datasets.pdf` in the team
+repo.
+
+## IEC / IEEE standards encoding
+
+DGA-related ground truth (fault codes, condition tiers, gas thresholds) is
+encoded in `data/knowledge/transformer_standards.json` in the team repo. That
+artifact reflects:
+
+- **IEC 60599:2022** (4th ed., publication 66491) — Rogers Ratio method,
+  fault-table boundaries, representative gas profiles
+- **IEEE C57.104-2019** — condition framework (C1–C4) and gas threshold values
+
+The FMSR server's `analyze_dga` tool implements the Rogers Ratio method
+directly from this artifact, so generated DGA records and server outputs are
+mutually consistent.
+
+## Citation
+
+SmartGridBench: A Smart Grid transformer maintenance benchmark for MCP-enabled
+LLM agents. Team 13, HPML Spring 2026, Columbia University.
+*Citation will be updated when the NeurIPS 2026 Datasets & Benchmarks
+submission is finalized.*

--- a/docs/smart_grid_data_provenance.md
+++ b/docs/smart_grid_data_provenance.md
@@ -34,7 +34,7 @@ Six synthetic CSV files, one per logical data slice:
 
 | File | Server(s) | Description |
 |---|---|---|
-| `asset_metadata.csv` | IoT | Static nameplate data per transformer (ID, rating, criticality, install date) |
+| `asset_metadata.csv` | IoT | Static nameplate data per transformer (`transformer_id`, `name`, `manufacturer`, `location`, `voltage_class`, `rating_kva`, `install_date`, `age_years`, `health_status`, `fdd_category`, `rul_days`, `in_service`) |
 | `sensor_readings.csv` | IoT, TSFM | Time-series sensor readings (load current, winding temp, oil temp, voltage) |
 | `failure_modes.csv` | FMSR | Failure mode catalogue with severity, IEC code, and recommended action |
 | `dga_records.csv` | FMSR | Dissolved Gas Analysis (DGA) records per transformer, per sample date |
@@ -42,11 +42,10 @@ Six synthetic CSV files, one per logical data slice:
 | `fault_records.csv` | WO | Historical fault and maintenance event records |
 
 All values are synthetic. Gas concentrations in `dga_records.csv` are
-calibrated against the IEC 60599:2022 Rogers Ratio fault-table boundaries
-encoded in
-[`data/knowledge/transformer_standards.json`](../../data/knowledge/transformer_standards.json)
-in the team repo, so `analyze_dga` tool outputs are internally consistent with
-the ground-truth labels.
+derived from the team's data pipeline; the IEC 60599:2022 Rogers Ratio
+fault-table boundaries used for DGA classification are encoded in
+`data/knowledge/transformer_standards.json` in the team repo
+(see `HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp`).
 
 ## No-CSV-port policy
 
@@ -100,8 +99,12 @@ artifact reflects:
 - **IEEE C57.104-2019** — condition framework (C1–C4) and gas threshold values
 
 The FMSR server's `analyze_dga` tool implements the Rogers Ratio method
-directly from this artifact, so generated DGA records and server outputs are
-mutually consistent.
+using the fault-table boundaries from that artifact. Note: the AOB fork
+server encodes the table directly in `src/servers/smart_grid/fmsr/main.py`
+rather than reading the JSON at runtime. Downstream users regenerating DGA
+records should verify that generated gas values round-trip correctly through
+`analyze_dga` for their intended fault labels before using them as benchmark
+ground truth.
 
 ## Citation
 


### PR DESCRIPTION
## Summary

- New doc at `docs/smart_grid_data_provenance.md` for upstream AOB reviewers
- Explains `SG_DATA_DIR` semantics and the `./data/sg_processed/` default (confirmed from `src/servers/smart_grid/base.py`)
- Documents the six CSVs, their domain mappings, and the data sources they came from
- Explains the no-CSV-port policy and how downstream users can regenerate the data
- Includes IEC/IEEE standards provenance for the DGA encoding

Closes #14.

## Test plan

- [ ] Doc renders cleanly in GitHub markdown
- [ ] Default path matches `_resolve_data_dir()` in `base.py`
- [ ] No class-only raw artifacts referenced by file path