### PR TITLE
feat(smart_grid): port full HPML 31-scenario corpus (closes AOB #30 + #31)

### DIFF
--- a/src/scenarios/local/smart_grid.json
+++ b/src/scenarios/local/smart_grid.json
@@ -68,6 +68,100 @@
     ]
   },
   {
+    "id": "SGT-013",
+    "type": "FMSR",
+    "text": "Field technicians on T-003 reported intermittent partial discharge symptoms during their last inspection. Identify the failure mode that best matches this symptom and list the sensor readings most useful for confirming and tracking its progression.",
+    "category": "Symptom-Driven Failure Mode Lookup",
+    "characteristic_form": "The answer should identify a specific failure mode matching the symptom, cite the match rationale, and list the sensors most correlated with tracking that mode.",
+    "asset_id": "T-003",
+    "expected_tools": [
+      "fmsr.search_failure_modes",
+      "fmsr.get_sensor_correlation"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "matched failure mode",
+        "rationale",
+        "correlated sensors"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-014",
+    "type": "FMSR",
+    "text": "T-014's most recent oil sample has returned elevated gas readings flagged during laboratory review. Diagnose the probable fault mode, identify the closest matching failure mechanism in the catalogue, and specify which sensors should be prioritized for ongoing monitoring.",
+    "category": "Full DGA Diagnostic Chain",
+    "characteristic_form": "The answer should state the DGA-derived fault mode, match it to a catalogue failure mechanism with rationale, and recommend a prioritized sensor monitoring list.",
+    "asset_id": "T-014",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga",
+      "fmsr.search_failure_modes",
+      "fmsr.get_sensor_correlation"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "fault mode from DGA",
+        "matched failure mechanism",
+        "sensors for ongoing monitoring"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-023",
+    "type": "FMSR",
+    "text": "Pull the dissolved gas analysis record on file for T-013 and explain what the gas profile suggests about the unit. Identify the dominant gases, then look up which failure mode in the catalogue best matches that gas signature.",
+    "category": "DGA Record Interpretation",
+    "characteristic_form": "The answer should report the stored DGA gas concentrations for T-013, identify which gases dominate the profile, and name the matching failure mode from the catalogue with its severity tier and recommended action.",
+    "asset_id": "T-013",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.search_failure_modes"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA gas values",
+        "dominant gases",
+        "matching failure mode",
+        "severity tier",
+        "recommended action"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-024",
+    "type": "FMSR",
+    "text": "Operations is preparing a spare-parts and inspection plan focused on worst-case scenarios. From the failure mode catalogue, surface only the modes flagged at high or critical severity and pair each with its recommended maintenance action.",
+    "category": "Severity-Filtered Failure Mode Review",
+    "characteristic_form": "The answer should list every failure mode whose severity is either high or critical, give the descriptive label or IEC code for each, and pair it with the recommended maintenance action drawn from the catalogue.",
+    "expected_tools": [
+      "fmsr.list_failure_modes"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "high severity modes",
+        "critical severity modes",
+        "recommended action per mode"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
     "id": "SGT-001",
     "type": "IoT",
     "text": "List all available sensors for transformer T-011 and include each sensor's latest timestamped value.",
@@ -108,6 +202,103 @@
         "max deviation",
         "time of exceedance or no exceedance",
         "clear yes/no decision"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-011",
+    "type": "IoT",
+    "text": "Identify all transformers in the fleet currently showing degraded or poor health status. For each flagged asset, retrieve its nameplate data and summarize which units require prioritized attention.",
+    "category": "Fleet Health Assessment",
+    "characteristic_form": "The answer should enumerate degraded assets by ID, include nameplate metadata for each, and rank or flag the units most in need of follow-up.",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.get_asset_metadata"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "list of degraded asset IDs",
+        "nameplate data per asset",
+        "prioritization or ranking"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-012",
+    "type": "IoT",
+    "text": "T-005 has been logging elevated load current readings over the past week. Retrieve the recent sensor data and determine whether current readings are abnormally high relative to the recent baseline, and flag the peak recorded value and when it occurred.",
+    "category": "Load Current Monitoring",
+    "characteristic_form": "The answer should retrieve load current readings for T-005, compute or reference a recent baseline, state whether readings are elevated above that baseline, and report the peak value and timestamp.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "load current readings",
+        "baseline or mean reference",
+        "peak value and timestamp",
+        "elevated vs normal assessment"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-021",
+    "type": "IoT",
+    "text": "T-007 is one of the high-voltage transmission units in the fleet. List its asset metadata and the full set of sensors currently installed, and flag whether the available instrumentation covers both electrical and thermal monitoring needs.",
+    "category": "Sensor Coverage Audit",
+    "characteristic_form": "The answer should report the transformer's voltage class and rating, list all installed sensor IDs, and summarize whether thermal channels (e.g. winding/oil temperature) and electrical channels (e.g. load current, voltage) are both represented.",
+    "asset_id": "T-007",
+    "expected_tools": [
+      "iot.get_asset_metadata",
+      "iot.list_sensors"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "voltage class",
+        "rating",
+        "sensor list",
+        "thermal sensor coverage",
+        "electrical sensor coverage"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-022",
+    "type": "IoT",
+    "text": "Provide a quick fleet-status snapshot. Enumerate the transformers currently in service, then for one representative healthy unit (T-005) and one degraded unit (T-013) surface the available sensor channels and a recent telemetry sample for each channel so a comparative read of operational state can be made.",
+    "category": "Fleet Status Snapshot",
+    "characteristic_form": "The answer should list the in-service transformer IDs, then for each of T-005 and T-013 surface the available sensor channels and a recent telemetry sample for each channel, and call out any qualitative difference between the two units.",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "in-service transformer list",
+        "T-005 sensor channels",
+        "T-005 sample readings",
+        "T-013 sensor channels",
+        "T-013 sample readings",
+        "comparative observation"
       ]
     },
     "difficulty": "medium",
@@ -173,6 +364,169 @@
     ]
   },
   {
+    "id": "SGT-016",
+    "type": "Multi",
+    "text": "T-001 is a critical substation transformer with no spare unit available. Assess its remaining useful life, identify which sensors are available and check them for anomalies over the past 30 days, and determine whether the current condition supports continued operation through the next planned 90-day maintenance window.",
+    "category": "Comprehensive Health Assessment",
+    "characteristic_form": "The answer should retrieve available sensors, report an RUL estimate, identify any anomalies in the past 30 days, and give a clear go/no-go recommendation for the 90-day operating window, noting the no-spare constraint.",
+    "asset_id": "T-001",
+    "expected_tools": [
+      "iot.list_sensors",
+      "tsfm.get_rul",
+      "tsfm.forecast_rul",
+      "tsfm.detect_anomalies",
+      "tsfm.trend_analysis"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "sensor list retrieved",
+        "RUL estimate",
+        "anomaly findings",
+        "90-day go/no-go recommendation",
+        "no-spare constraint acknowledged"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "IoT",
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-019",
+    "type": "Multi",
+    "text": "T-004 has been carrying near-peak load for several weeks. Identify the available sensors, review recent telemetry and any thermal trends, and assess whether the current condition poses a risk to sustained operation over the next 90 days.",
+    "category": "Thermal Risk Assessment",
+    "characteristic_form": "The answer should list available sensors for T-004, summarize relevant IoT sensor readings, report the thermal trend direction and rate, flag any anomalies, and give a 90-day operational risk assessment.",
+    "asset_id": "T-004",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings",
+      "tsfm.trend_analysis",
+      "tsfm.detect_anomalies",
+      "tsfm.forecast_rul"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "sensor list retrieved",
+        "sensor telemetry summary",
+        "thermal trend finding",
+        "anomaly findings",
+        "90-day operational risk assessment"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT",
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-020",
+    "type": "Multi",
+    "text": "T-016 tripped on differential protection overnight. Review its DGA data and fault record history to determine what the available evidence supports, then issue a corrective work order with a priority level appropriate to the overall situation.",
+    "category": "Protection Trip Response",
+    "characteristic_form": "The answer should retrieve and analyze DGA data (noting whether the result is diagnostic or inconclusive), reference prior fault history, and produce a corrective work order with a priority level justified by the combined evidence from the protection trip event, fault history, and component health.",
+    "asset_id": "T-016",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga",
+      "wo.list_fault_records",
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA retrieved and result noted",
+        "fault history cited",
+        "corrective work order issued",
+        "WO priority justified by protection trip and fault history"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR",
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-025",
+    "type": "Multi",
+    "text": "Operators flagged a short window of unusual top-of-winding temperature readings on T-014 over the last few days. First identify the sensor channels installed on this asset, then run an anomaly check and trend analysis on the winding temperature channel (winding_temp_top_c) to determine whether the deviations form a single burst or a sustained shift.",
+    "category": "Anomaly Burst vs Trend Disambiguation",
+    "characteristic_form": "The answer should first surface the available sensor channels for T-014, then for the winding_temp_top_c channel report the anomaly findings and recent trend direction, and conclude whether the disturbance is an isolated burst or a sustained drift in the underlying signal.",
+    "asset_id": "T-014",
+    "expected_tools": [
+      "iot.list_sensors",
+      "tsfm.detect_anomalies",
+      "tsfm.trend_analysis"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "sensor channels available",
+        "winding_temp_top_c anomaly findings",
+        "winding_temp_top_c trend direction",
+        "burst vs sustained classification"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT",
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-029",
+    "type": "Multi",
+    "text": "T-019 has just had a fresh oil sample analysed and the DGA record is now on file. Review that gas profile, identify the most likely failure mode it points to, and convert that finding into a corrective inspection work order whose priority reflects the implied severity.",
+    "category": "DGA Finding to Inspection Work Order",
+    "characteristic_form": "The answer should report the stored DGA values for T-019, name the matching failure mode and its severity tier, and create a work order whose priority and scope are explicitly justified by the DGA-derived severity.",
+    "asset_id": "T-019",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.search_failure_modes",
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA gas values",
+        "matching failure mode",
+        "severity tier",
+        "work order created",
+        "priority justification"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR",
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-030",
+    "type": "Multi",
+    "text": "End-of-quarter fleet review has identified T-020 (critical-tier) as a candidate for accelerated maintenance. Pull the RUL forecast over a 90-day horizon, then create a work order whose scope and priority are explicitly justified by both the current RUL and the projected RUL at the end of that horizon.",
+    "category": "RUL Forecast-Driven Work Order",
+    "characteristic_form": "The answer should report the RUL forecast for T-020 — including the current RUL and the projected RUL at the 90-day horizon — and create a work order whose priority and scope are explicitly justified by the magnitude of that change (e.g. emergency vs short-term corrective).",
+    "asset_id": "T-020",
+    "expected_tools": [
+      "tsfm.forecast_rul",
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "current RUL value",
+        "projected RUL at 90-day horizon",
+        "work order created",
+        "priority justification"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "TSFM",
+      "WO"
+    ]
+  },
+  {
     "id": "SGT-005",
     "type": "TSFM",
     "text": "Forecast remaining useful life for transformer T-016 and state whether it can safely operate for the next 180 days without major maintenance.",
@@ -218,6 +572,52 @@
     ]
   },
   {
+    "id": "SGT-015",
+    "type": "TSFM",
+    "text": "T-002's winding temperature sensor (winding_temp_top_c) has shown irregular readings over the past month. Analyze the recent trend and report whether readings are increasing, decreasing, or stable, along with the rate of change and how well the trend fits the data.",
+    "category": "Sensor Trend Analysis",
+    "characteristic_form": "The answer should report the trend direction (increasing, decreasing, or stable), the slope rate per day, and the R-squared fit quality for T-002's winding_temp_top_c sensor.",
+    "asset_id": "T-002",
+    "expected_tools": [
+      "tsfm.trend_analysis"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "trend direction",
+        "slope rate",
+        "R-squared or fit quality"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-026",
+    "type": "TSFM",
+    "text": "Capital planning needs a defensible RUL view for T-011 ahead of the next budget cycle. Pull the current RUL estimate and a 180-day forecast, compare the two, and state whether the comparison supports deferring replacement or argues for advancing it.",
+    "category": "RUL Current vs Forecast Comparison",
+    "characteristic_form": "The answer should report the current RUL estimate for T-011, the forecasted RUL at the 180-day horizon, and a recommendation on whether the comparison supports deferring or advancing replacement, citing the magnitude of any change.",
+    "asset_id": "T-011",
+    "expected_tools": [
+      "tsfm.get_rul",
+      "tsfm.forecast_rul"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "current RUL value",
+        "forecast RUL value",
+        "comparison",
+        "deferral or advance recommendation"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "TSFM"
+    ]
+  },
+  {
     "id": "SGT-007",
     "type": "WO",
     "text": "Create a preventive inspection work order for transformer T-013 for the next maintenance cycle, including priority, required skills, and estimated downtime.",
@@ -257,6 +657,105 @@
         "priority decision",
         "justification",
         "corrective tasks"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-017",
+    "type": "WO",
+    "text": "T-009 is approaching its next scheduled maintenance cycle. Review its recent fault history and any open work orders to determine whether anything requires priority escalation before the maintenance window begins.",
+    "category": "Pre-Maintenance Review",
+    "characteristic_form": "The answer should list recent fault records for T-009, summarize open work orders, and state whether any item requires escalation with a brief justification.",
+    "asset_id": "T-009",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "wo.list_work_orders"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "fault record summary",
+        "open work order summary",
+        "escalation decision with justification"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-018",
+    "type": "WO",
+    "text": "A fault event was recently logged on T-006. Retrieve the fault details, estimate the expected repair downtime, open a corrective work order, and then mark it as in-progress with the estimated duration recorded.",
+    "category": "Work Order Lifecycle",
+    "characteristic_form": "The answer should retrieve the fault record, estimate downtime, create a corrective work order, and update its status to in-progress with the downtime noted.",
+    "asset_id": "T-006",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "wo.get_fault_record",
+      "wo.estimate_downtime",
+      "wo.create_work_order",
+      "wo.update_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "fault record details",
+        "downtime estimate",
+        "corrective work order created",
+        "work order updated to in-progress"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-027",
+    "type": "WO",
+    "text": "An inspection on T-009 has just been completed in the field with no abnormal condition observed. Open a work order documenting that the inspection took place, then close it out with a note recording the clean inspection result.",
+    "category": "Work Order Lifecycle (Open and Close)",
+    "characteristic_form": "The answer should report the newly created work order identifier and its initial status, then confirm a follow-up update that transitions the work order to a closed state with a closure note referencing the clean inspection finding.",
+    "asset_id": "T-009",
+    "expected_tools": [
+      "wo.create_work_order",
+      "wo.update_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "work order identifier",
+        "initial open status",
+        "status updated to closed",
+        "closure note recorded"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-028",
+    "type": "WO",
+    "text": "Planning needs a downtime estimate for T-018 ahead of an upcoming high-severity corrective outage. Review the recent fault history to characterize the typical event class for this unit, then produce a downtime estimate at the high severity tier with assumptions justified by that history.",
+    "category": "Downtime Estimation for Planned Outage",
+    "characteristic_form": "The answer should summarize the recent fault record entries for T-018, identify the dominant fault class or repair pattern, and report a downtime estimate in hours at the high severity tier along with the assumptions that justify it.",
+    "asset_id": "T-018",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "wo.estimate_downtime"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "fault history summary",
+        "dominant fault class",
+        "downtime estimate hours",
+        "high severity tier",
+        "estimation assumptions"
       ]
     },
     "difficulty": "medium",

--- a/src/servers/smart_grid/tests/test_scenarios.py
+++ b/src/servers/smart_grid/tests/test_scenarios.py
@@ -35,7 +35,12 @@ def _load(filename: str) -> list[dict]:
 
 def test_smart_grid_scenarios_count():
     records = _load("smart_grid.json")
-    assert len(records) == 11
+    # Phase-2 floor: 11 hand-picked subset → expanded to the full HPML
+    # 31-scenario corpus (HPML #15 closed at 15+, HPML #33 closed at 30+)
+    # in this PR. AOB-FMSR-001 is the original AOB-style scenario; the
+    # other 30 are SGT-NNN ports from data/scenarios/*.json in the HPML
+    # repo, format-identical (same field set, same ground_truth shape).
+    assert len(records) == 31
 
 
 def test_smart_grid_negative_checks_count():


### PR DESCRIPTION
## Summary

Ports the full HPML Smart Grid scenario corpus into AOB's array format. **Closes AOB #30** (15+ canonical port) **and AOB #31** (30+ corpus expansion) in one PR — both issues' acceptance criteria are met by the same change since the HPML repo already validated all 31 scenarios as a single corpus (HPML #15 closed at 15+, HPML #33 closed at 30+).

## What changed

- `src/scenarios/local/smart_grid.json` — array grew from 11 → 31 records. The 20 newly-added scenarios are SGT-NNN ports from `data/scenarios/*.json` in the HPML repo. Format is identical (same 10 canonical fields), so no per-scenario rewriting was needed — only packing into the array.
- `src/servers/smart_grid/tests/test_scenarios.py` — `test_smart_grid_scenarios_count` floor bumped from 11 to 31, with a comment naming HPML #15/#33 as the source-of-truth.

Negative fixtures (`src/scenarios/local/smart_grid_negative_checks.json`) are unchanged — all 5 `SG-NEG-*` records were already in AOB and match HPML's `data/scenarios/negative_checks/`.

## Ordering

Sorted by domain block (FMSR → IoT → Multi → TSFM → WO), IDs sorted within each block. AOB-FMSR-001 (the original AOB-style scenario) stays at the top of the FMSR block.

| Block | IDs |
|---|---|
| FMSR | AOB-FMSR-001, SGT-003, SGT-004, **SGT-013, SGT-014, SGT-023, SGT-024** |
| IoT  | SGT-001, SGT-002, **SGT-011, SGT-012, SGT-021, SGT-022** |
| Multi | SGT-009, SGT-010, **SGT-016, SGT-019, SGT-020, SGT-025, SGT-029, SGT-030** |
| TSFM | SGT-005, SGT-006, **SGT-015, SGT-026** |
| WO | SGT-007, SGT-008, **SGT-017, SGT-018, SGT-027, SGT-028** |

(Bold = added by this PR.)

## Field-shape parity

Every HPML scenario uses the same 10 canonical fields as AOB's existing array (`id, type, text, category, characteristic_form, expected_tools, ground_truth, difficulty, domain_tags`, plus optional `asset_id`). A few `ground_truth` blocks carry domain-meaningful extras (`threshold_percent`, `decision_window_days`) — preserved verbatim, since `evaluation.models.Scenario.from_raw()` uses `extra='allow'` so they round-trip without loss.

No CSV/data-file ports — this PR only touches scenario JSON + the count test, consistent with `tanisha/sg-data-provenance-doc` (#34) which established the no-CSV-port policy.

## Test plan

- [x] `uv run pytest src/servers/smart_grid/` — 25 passed (5 scenario tests + 20 fmsr/direct-adapter tests).
- [x] `test_smart_grid_scenario_ids_unique` confirms no ID collisions across `smart_grid.json` + `smart_grid_negative_checks.json`.
- [x] `test_smart_grid_scenarios_validate_via_aob_scenario_model` round-trips every record through `evaluation.models.Scenario.from_raw()`.
- [ ] Reviewer spot-check: pick a newly-added scenario, diff against its HPML source file (e.g. `multi_05_dga_to_inspection_workorder.json` ↔ array entry `SGT-029`), confirm field-by-field equality.
- [ ] Reviewer spot-check: confirm domain-block ordering and that IDs are sorted within each block.

## Refs

- HPML #15 (closed, 15+ scenarios reached)
- HPML #33 (closed, 30+ scenarios reached)
- HPML PR #175 (hand-authored 31-scenario corpus that this PR ports)
- Builds on `aob/sg-domain-port` (the existing 11-scenario AOB conversion)