### PR TITLE
feat(smart_grid): port SGT-031..SGT-060 — 50+ corpus (AOB #36)

### DIFF
--- a/src/scenarios/local/smart_grid.json
+++ b/src/scenarios/local/smart_grid.json
@@ -762,5 +762,1039 @@
     "domain_tags": [
       "WO"
     ]
+  },
+  {
+    "id": "SGT-031",
+    "type": "FMSR",
+    "text": "Transformer T-005 shows stable gas levels during routine monitoring. Confirm whether any fault is indicated and recommend the next monitoring step.",
+    "category": "Fault Diagnosis",
+    "characteristic_form": "A normal/no-fault confirmation with a routine-monitoring recommendation.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "domain_tags": [
+      "FMSR"
+    ],
+    "difficulty": "medium",
+    "ground_truth": {
+      "ideal_tool_sequence": [
+        "fmsr.get_dga_record",
+        "fmsr.analyze_dga"
+      ],
+      "decisive_intermediate_values": {
+        "iec_code": "N",
+        "final_sample_gases_ppm": {
+          "H2": 12.31,
+          "CH4": 8.03,
+          "C2H2": 0.17,
+          "C2H4": 2.07,
+          "C2H6": 0.71
+        },
+        "condition": "normal/background gas profile"
+      },
+      "final_value": {
+        "primary_fault": "Normal/no active fault",
+        "recommended_action": "Continue routine monitoring; no immediate inspection beyond the scheduled interval"
+      },
+      "acceptance_criteria": [
+        "agent identifies no active fault or an N/normal DGA profile",
+        "agent recommends continued routine monitoring or equivalent non-urgent follow-up",
+        "agent uses the background gas profile to justify the non-fault diagnosis"
+      ],
+      "must_include": [
+        "normal/no active fault",
+        "recommended monitoring action",
+        "background gas rationale"
+      ]
+    },
+    "provenance": {
+      "source_type": "generated",
+      "generator_prompt_version": "v0.1",
+      "knowledge_plugin_version": "0eacec24441e",
+      "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "generation_date": "2026-05-03T03:25:40.482330+00:00",
+      "batch_id": "first_review_20260502",
+      "manual_cleanup": true,
+      "cleanup_notes": "Corrected generated ground truth from contradictory T3 diagnosis to N/normal based on the committed stable_normal prompt template and final-sample R1=0.056.",
+      "promotion": {
+        "promoted_from": "data/scenarios/generated/first_review_20260502/SGT-GEN-001.json",
+        "disposition_csv": "data/scenarios/generated/disposition_2026-05-06.csv",
+        "applied_edits": [
+          "Replaced fabricated decisive_intermediate_values.final_sample_gases_ppm with the actual T-005 DGA values from data/processed/dga_records.csv (h2=12.31, ch4=8.03, c2h2=0.17, c2h4=2.07, c2h6=0.71).",
+          "Dropped the fabricated R1/R2/R3 ratios — agent should derive these from analyze_dga rather than be scored against pre-computed values that may drift if the synthesis is re-run.",
+          "Updated nearest_handcrafted_comparator from fmsr_01_dga_fault_mode_diagnosis (SGT-003) to fmsr_05_dga_record_lookup_explain (SGT-023) per reviewer-selected comparator in disposition CSV."
+        ]
+      }
+    },
+    "family": "FMSR_DGA_DIAGNOSIS",
+    "nearest_handcrafted_comparator": {
+      "scenario_id": "SGT-023",
+      "scenario_file": "data/scenarios/fmsr_05_dga_record_lookup_explain.json",
+      "similarity_basis": "shares type='FMSR' and overlaps on fmsr.get_dga_record; both interpret a stored DGA record. This generated scenario is novel in asking for an explicit non-fault confirmation rather than mapping gases to a failure mode.",
+      "novelty_note": "promoted as accept_with_edits: distinct angle (Normal-confirmation) from fmsr_05's dominant-gas-to-failure-mode pattern.",
+      "nearest_match_weak": false
+    }
+  },
+  {
+    "id": "SGT-032",
+    "type": "IoT",
+    "text": "Transformer T-005 is operating at 98% capacity with no spare available. Retrieve the recent oil-temperature readings, report the recent baseline (mean) and peak value with timestamp, and state whether the peak is elevated relative to the baseline.",
+    "category": "Sensor Analysis",
+    "characteristic_form": "The answer should retrieve oil_temp_c readings for T-005 from iot.get_sensor_readings, compute or reference a recent baseline (mean), report the peak value and its timestamp, and assess whether the peak is elevated relative to baseline — all from actual tool output rather than a pre-stated absolute threshold.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "domain_tags": [
+      "IoT"
+    ],
+    "difficulty": "easy",
+    "ground_truth": {
+      "ideal_tool_sequence": [
+        "iot.list_sensors",
+        "iot.get_sensor_readings"
+      ],
+      "decisive_intermediate_values": {
+        "sensor_id": "oil_temp_c"
+      },
+      "must_include": [
+        "oil_temp_c readings",
+        "baseline or mean reference",
+        "peak value and timestamp",
+        "elevated vs normal assessment"
+      ]
+    },
+    "provenance": {
+      "source_type": "generated",
+      "generator_prompt_version": "v0.1",
+      "knowledge_plugin_version": "0eacec24441e",
+      "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "generation_date": "2026-05-03T03:26:11.457400+00:00",
+      "batch_id": "first_review_20260502",
+      "manual_cleanup": false,
+      "promotion": {
+        "promoted_from": "data/scenarios/generated/first_review_20260502/SGT-GEN-004.json",
+        "disposition_csv": "data/scenarios/generated/disposition_2026-05-06.csv",
+        "applied_edits": [
+          "Added iot.list_sensors as the discovery step before iot.get_sensor_readings — both in expected_tools and in ground_truth.ideal_tool_sequence.",
+          "Dropped fabricated decisive_intermediate_values.oil_temp_c='70' (T-005 oil_temp_c never reaches 70 in data/processed/sensor_readings.csv: min=22.6, max=65.5, mean=45.0).",
+          "Dropped fabricated final_value.sensor_value_with_unit='70 deg C' and final_value.status_summary='normal operation'.",
+          "PR #195 v2 (review High 2): reframed the task from an absolute 'safe range' check to a data-grounded baseline/peak assessment. The original 'is the latest reading within a safe range?' question had no documented oil-temperature threshold available through the intended tool path (`iot.list_sensors` + `iot.get_sensor_readings` return only timestamp/value/unit; no oil-temp limit is documented in `docs/knowledge/scenario_generation_support.json` or `data/knowledge/transformer_standards.json`). The reframed task asks for the recent baseline + peak + timestamp + elevated-vs-normal assessment — all computable from the tool output. Mirrors `iot_04_load_current_overload_check.json` (the reviewer-selected comparator).",
+          "Dropped final_value and acceptance_criteria fields whose content is now subsumed by the data-grounded must_include list.",
+          "Updated nearest_handcrafted_comparator from iot_01_list_transformer_sensors (SGT-001) to iot_04_load_current_overload_check (SGT-012) per reviewer-selected comparator."
+        ]
+      }
+    },
+    "family": "IOT_SENSOR_ANALYSIS",
+    "nearest_handcrafted_comparator": {
+      "scenario_id": "SGT-012",
+      "scenario_file": "data/scenarios/iot_04_load_current_overload_check.json",
+      "similarity_basis": "both ask for a baseline + peak assessment over recent sensor readings on a single transformer sensor.",
+      "novelty_note": "different sensor (oil_temp_c vs load_current_a) and different operational framing (capacity-stress oil-temp baseline check vs week-long load-current overload assessment).",
+      "nearest_match_weak": false
+    }
+  },
+  {
+    "id": "SGT-033",
+    "type": "IoT",
+    "text": "Transformer T-005 is operating near peak load. Retrieve the recent winding-temperature readings, identify the peak value with timestamp, and determine whether it exceeds the documented 95°C operating limit (per docs/knowledge/scenario_generation_support.json).",
+    "category": "Sensor Analysis",
+    "characteristic_form": "The answer should retrieve winding_temp_top_c readings for T-005 from iot.get_sensor_readings, report the peak value with its timestamp, compare against the 95°C operating limit named in the prompt, and state whether the limit was breached.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "domain_tags": [
+      "IoT"
+    ],
+    "difficulty": "easy",
+    "ground_truth": {
+      "ideal_tool_sequence": [
+        "iot.list_sensors",
+        "iot.get_sensor_readings"
+      ],
+      "decisive_intermediate_values": {
+        "sensor_id": "winding_temp_top_c",
+        "operating_limit_c": 95,
+        "operating_limit_source": "docs/knowledge/scenario_generation_support.json -> alarm_correlation_examples (winding_temp_sensor)"
+      },
+      "must_include": [
+        "winding_temp_top_c peak value and timestamp",
+        "comparison against 95°C operating limit",
+        "limit-breach status"
+      ]
+    },
+    "provenance": {
+      "source_type": "generated",
+      "generator_prompt_version": "v0.1",
+      "knowledge_plugin_version": "0eacec24441e",
+      "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "generation_date": "2026-05-04T03:54:47.760089+00:00",
+      "batch_id": "first_review_20260503",
+      "manual_cleanup": false,
+      "promotion": {
+        "promoted_from": "data/scenarios/generated/first_review_20260503/SGT-GEN-004.json",
+        "disposition_csv": "data/scenarios/generated/disposition_2026-05-06.csv",
+        "applied_edits": [
+          "Added iot.list_sensors as the discovery step before iot.get_sensor_readings — both in expected_tools and in ground_truth.ideal_tool_sequence.",
+          "Dropped fabricated decisive_intermediate_values.winding_temp_top_c='80' (this was the fixture max, not a typical reading; T-005 winding_temp_top_c: min=21.2, max=80.0, mean=50.4 in data/processed/sensor_readings.csv).",
+          "Pinned sensor_id='winding_temp_top_c'.",
+          "PR #195 v2 (review High 2): the original 'within safe limits' phrasing did not name the limit. Updated the prompt + ground truth to cite the documented 95°C operating limit from `docs/knowledge/scenario_generation_support.json` (alarm_correlation_examples > winding_temp_sensor > iot_signal.threshold_note: 'exceeds 95°C operating limit'). The agent now has an explicit number to compare the reading against, and the rubric can verify the comparison without inventing a threshold.",
+          "Recorded operating_limit_c=95 and operating_limit_source in decisive_intermediate_values so the rubric can audit the threshold-source pairing.",
+          "Dropped final_value and acceptance_criteria fields whose content is now subsumed by the data-grounded must_include list.",
+          "Updated nearest_handcrafted_comparator from iot_01_list_transformer_sensors (SGT-001) to iot_04_load_current_overload_check (SGT-012) per reviewer-selected comparator."
+        ]
+      }
+    },
+    "family": "IOT_SENSOR_ANALYSIS",
+    "nearest_handcrafted_comparator": {
+      "scenario_id": "SGT-012",
+      "scenario_file": "data/scenarios/iot_04_load_current_overload_check.json",
+      "similarity_basis": "both ask for a peak-value assessment over recent sensor readings on a single transformer sensor with a stated reference (baseline for iot_04, 95°C operating limit here).",
+      "novelty_note": "different sensor (winding_temp_top_c vs load_current_a) on the same asset, with an explicit standards-derived threshold rather than a baseline-relative judgment.",
+      "nearest_match_weak": false
+    }
+  },
+  {
+    "id": "SGT-034",
+    "type": "WO",
+    "text": "T-003 substation main transformer temperature has exceeded threshold (severity: high) with spare procurement pending. Decide on maintenance and create a corrective work order, using historical fault context for the downtime estimate.",
+    "category": "Work Order Creation",
+    "characteristic_form": "A decision on work order creation with a derived priority and minimum playbook fields, using fault history to estimate downtime under a high-severity precondition.",
+    "asset_id": "T-003",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "wo.estimate_downtime",
+      "wo.create_work_order"
+    ],
+    "domain_tags": [
+      "WO"
+    ],
+    "difficulty": "medium",
+    "ground_truth": {
+      "ideal_tool_sequence": [
+        "wo.list_fault_records",
+        "wo.estimate_downtime",
+        "wo.create_work_order"
+      ],
+      "decisive_intermediate_values": {
+        "fault_type": "thermal",
+        "spare_status": "on_order",
+        "severity": "high"
+      },
+      "final_value": {
+        "work_order_type": "corrective",
+        "priority": "high",
+        "minimum_fields_from_playbook": true
+      },
+      "acceptance_criteria": [
+        "agent looks up T-003's historical fault records before estimating downtime",
+        "agent passes the prompt-stated severity ('high') into wo.estimate_downtime rather than guessing",
+        "agent creates a corrective work order at high priority with the minimum playbook fields"
+      ],
+      "must_include": [
+        "work_order_type",
+        "priority",
+        "minimum_fields_from_playbook"
+      ]
+    },
+    "provenance": {
+      "source_type": "generated",
+      "generator_prompt_version": "v0.2",
+      "knowledge_plugin_version": "0eacec24441e",
+      "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "generation_date": "2026-05-05T04:44:58.104378+00:00",
+      "batch_id": "v02_first_review_20260505",
+      "manual_cleanup": false,
+      "promotion": {
+        "promoted_from": "data/scenarios/generated/v02_first_review_20260505/SGT-GEN-003.json",
+        "disposition_csv": "data/scenarios/generated/disposition_2026-05-06.csv",
+        "applied_edits": [
+          "Pinned severity='high' explicitly in the prompt text and in decisive_intermediate_values. The v0.2 prompt fix added wo.list_fault_records before wo.estimate_downtime, but list_fault_records does not surface a severity field (data/processed/fault_records.csv schema has no severity/priority column — verified against mcp_servers/wo_server/server.py:94-128). Without an explicit severity in the prompt, estimate_downtime would have no source for its required severity argument.",
+          "Reordered ideal_tool_sequence so wo.list_fault_records is first (the v0.2 fix); kept it explicit in expected_tools.",
+          "Updated nearest_handcrafted_comparator from wo_04_fault_record_downtime_update (SGT-018) to wo_02_corrective_order_after_fault (SGT-008) per reviewer-selected comparator."
+        ]
+      }
+    },
+    "family": "WO_CREATION",
+    "nearest_handcrafted_comparator": {
+      "scenario_id": "SGT-008",
+      "scenario_file": "data/scenarios/wo_02_corrective_order_after_fault.json",
+      "similarity_basis": "both create a corrective work order downstream of a thermal incident on T-003.",
+      "novelty_note": "novel operational context: spare procurement pending (which constrains the downtime estimate) and a temperature-threshold trigger; v0.2 prompt fix introduced the list_fault_records precondition.",
+      "nearest_match_weak": false
+    }
+  },
+  {
+    "id": "SGT-035",
+    "type": "IoT",
+    "text": "Transformer T-004 is operating near peak capacity. Retrieve the recent oil-temperature readings and assess the current operating range — report the minimum, mean, and maximum oil_temp_c observed in the recent window with timestamps for the extremes, and characterize the operating profile.",
+    "category": "Sensor Analysis",
+    "characteristic_form": "The answer should retrieve oil_temp_c readings for T-004 from iot.get_sensor_readings and report the min/mean/max with timestamps for the extremes, characterizing the recent operating range — all from actual tool output rather than a pre-stated absolute threshold.",
+    "asset_id": "T-004",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "domain_tags": [
+      "IoT"
+    ],
+    "difficulty": "easy",
+    "ground_truth": {
+      "ideal_tool_sequence": [
+        "iot.list_sensors",
+        "iot.get_sensor_readings"
+      ],
+      "decisive_intermediate_values": {
+        "sensor_id": "oil_temp_c"
+      },
+      "must_include": [
+        "oil_temp_c min, mean, and max values with units",
+        "timestamps for the min and max readings",
+        "operating-range characterization"
+      ]
+    },
+    "provenance": {
+      "source_type": "generated",
+      "generator_prompt_version": "v0.2",
+      "knowledge_plugin_version": "0eacec24441e",
+      "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "generation_date": "2026-05-05T04:45:06.796101+00:00",
+      "batch_id": "v02_first_review_20260505",
+      "manual_cleanup": false,
+      "promotion": {
+        "promoted_from": "data/scenarios/generated/v02_first_review_20260505/SGT-GEN-004.json",
+        "disposition_csv": "data/scenarios/generated/disposition_2026-05-06.csv",
+        "applied_edits": [
+          "Added iot.list_sensors as the discovery step before iot.get_sensor_readings — both in expected_tools and in ground_truth.ideal_tool_sequence (the v0.2 prompt fix pinned sensor_id but did not add the discovery step).",
+          "Dropped fabricated final_value.sensor_value_with_unit='70 deg C' and final_value.status_summary='normal operation' (T-004 oil_temp_c never reaches 70 in data/processed/sensor_readings.csv: min=13.9, max=69.8, mean=45.1).",
+          "Kept v0.2's decisive_intermediate_values.sensor_id='oil_temp_c' pin.",
+          "PR #195 v2 (review High 2): reframed from an absolute 'within normal range' check to an operating-range characterization. There is no documented oil-temperature limit available through the intended tool path (`iot.list_sensors` + `iot.get_sensor_readings` return only timestamp/value/unit). The reframed task asks for min/mean/max with timestamps — all computable from tool output. Differentiated from `iot_07_oil_temp_safe_range_check.json` (which focuses on baseline + peak elevation) by asking for the full operating range on a different asset (T-004 vs T-005).",
+          "Dropped final_value and acceptance_criteria fields whose content is now subsumed by the data-grounded must_include list.",
+          "Updated nearest_handcrafted_comparator from iot_01_list_transformer_sensors (SGT-001) to iot_04_load_current_overload_check (SGT-012) per reviewer-selected comparator."
+        ]
+      }
+    },
+    "family": "IOT_SENSOR_ANALYSIS",
+    "nearest_handcrafted_comparator": {
+      "scenario_id": "SGT-012",
+      "scenario_file": "data/scenarios/iot_04_load_current_overload_check.json",
+      "similarity_basis": "both ask for an operating-profile assessment over recent sensor readings on a single transformer sensor.",
+      "novelty_note": "different asset (T-004 vs T-005), different sensor (oil_temp_c vs load_current_a), and a min/mean/max range characterization rather than a peak-vs-baseline elevation check.",
+      "nearest_match_weak": false
+    }
+  },
+  {
+    "id": "SGT-036",
+    "type": "FMSR",
+    "text": "An incident report flagged arcing in T-018's last inspection. Search the failure-mode catalogue for any modes related to arcing or partial discharge, and for each one return its IEC code or descriptive label, severity tier, key symptoms, and recommended maintenance action.",
+    "category": "Symptom-Driven Failure Mode Lookup",
+    "characteristic_form": "The answer should list every catalogue failure mode that matches arcing-style keywords, give the IEC code or label, severity tier, key symptoms, and the recommended maintenance action for each.",
+    "expected_tools": [
+      "fmsr.search_failure_modes"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "matched failure modes",
+        "IEC code or descriptive label",
+        "severity tier",
+        "key symptoms",
+        "recommended maintenance action"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-037",
+    "type": "FMSR",
+    "text": "T-018's on-file DGA record carries a stored fault_label of 'Arc discharge'. Pull the record, run the analyzer (IEC 60599 / Rogers ratios), and reconcile any disagreement between the stored classification and the analyzer's output. Report both, name the disagreement (or confirmation) explicitly, and recommend the next maintenance step grounded in both signals.",
+    "category": "Fault Diagnosis",
+    "characteristic_form": "The answer should report the stored DGA gas concentrations and stored fault_label for T-018, the analyzer's IEC 60599 classification (which on the current fixture falls outside the D1/D2 ranges and therefore returns N or no-match), explicitly name the disagreement between the stored 'Arc discharge' label and the analyzer's output, and recommend a maintenance action that accounts for both signals (e.g. resample-to-confirm).",
+    "asset_id": "T-018",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA gas values from the on-file record",
+        "stored fault_label reported (Arc discharge)",
+        "analyzer IEC 60599 classification reported",
+        "explicit reconciliation of stored-label vs analyzer disagreement",
+        "recommended maintenance action grounded in both signals"
+      ],
+      "must_NOT_include": [
+        "claim that the analyzer confirmed Arc discharge / D1 / D2 on T-018's current fixture",
+        "stored fault_label reported as if it came from the analyzer"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-038",
+    "type": "FMSR",
+    "text": "T-013's on-file DGA record carries a stored fault_label of 'Low-temperature overheating'. Pull the record, run the analyzer (IEC 60599 / Rogers ratios), and reconcile any disagreement between the stored classification and the analyzer's output. Report both, name the disagreement (or confirmation) explicitly, and state what posture the maintenance team should adopt given the conflicting signals.",
+    "category": "Fault Diagnosis",
+    "characteristic_form": "The answer should report the stored DGA gas concentrations and stored fault_label for T-013, the analyzer's IEC 60599 classification (which on the current fixture sits below the thermal-row CH4/H2 ≥ 1.0 threshold and therefore returns N or no-match), explicitly name the disagreement between the stored 'Low-temperature overheating' label and the analyzer's output, and recommend a maintenance posture (e.g. resample-to-confirm, increased monitoring) grounded in both signals.",
+    "asset_id": "T-013",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA gas values from the on-file record",
+        "stored fault_label reported (Low-temperature overheating)",
+        "analyzer IEC 60599 classification reported",
+        "explicit reconciliation of stored-label vs analyzer disagreement",
+        "recommended maintenance posture grounded in both signals"
+      ],
+      "must_NOT_include": [
+        "claim that the analyzer confirmed T1/T2/T3 thermal-pattern fault on T-013's current fixture",
+        "stored fault_label reported as if it came from the analyzer"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR"
+    ]
+  },
+  {
+    "id": "SGT-039",
+    "type": "IoT",
+    "text": "Operations is checking that T-008's measured voltage ratio matches its nameplate. Pull the available sensor channels, sample recent HV and LV voltage readings, compare the measured ratio against the metadata-declared voltage class, and flag any deviation worth investigating.",
+    "category": "Sensor Analysis",
+    "characteristic_form": "The answer should report T-008's nameplate voltage class, sampled HV and LV voltage readings, the computed measured ratio, a comparison against the nameplate ratio, and a deviation flag (or an explicit no-deviation finding).",
+    "asset_id": "T-008",
+    "expected_tools": [
+      "iot.get_asset_metadata",
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "nameplate voltage class",
+        "HV voltage sample",
+        "LV voltage sample",
+        "computed measured ratio",
+        "ratio comparison and deviation flag"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-040",
+    "type": "IoT",
+    "text": "T-014 has been flagged for possible reactive-load issues. Surface its available sensor channels and pull the recent power-factor readings, then summarize whether the values stay near a stable baseline or show variability and dips worth investigating.",
+    "category": "Sensor Analysis",
+    "characteristic_form": "The answer should identify the power-factor sensor channel for T-014, report a recent reading sample with min/max or representative values, summarize stability versus variability, and call out any dips worth follow-up (or note their absence).",
+    "asset_id": "T-014",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "power-factor sensor identified",
+        "recent power-factor readings",
+        "stability or variability summary versus a baseline window",
+        "dips worth follow-up or none observed"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-041",
+    "type": "IoT",
+    "text": "Capital planning needs a fleet inventory grouped by voltage class and rating. List every transformer currently in service, pull nameplate data for each, and produce a grouping that calls out the highest-rated unit and any voltage-class outliers.",
+    "category": "Asset Discovery",
+    "characteristic_form": "The answer should enumerate the in-service transformer IDs, group them by voltage class with per-asset rating, identify the highest-rated unit, and call out any voltage-class outliers (or note their absence).",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.get_asset_metadata"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "in-service transformer list",
+        "voltage-class grouping",
+        "rating per asset",
+        "highest-rated unit identified",
+        "voltage-class outliers or none"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "IoT"
+    ]
+  },
+  {
+    "id": "SGT-042",
+    "type": "TSFM",
+    "text": "Recent reports suggest T-016 may be experiencing intermittent overcurrent excursions. Run anomaly detection on the load-current channel and report any detected events along with a brief characterization of their magnitude and timing.",
+    "category": "Anomaly Detection",
+    "characteristic_form": "The answer should confirm anomaly detection was run on the load_current_a channel for T-016, report the count and approximate timing of detected events, characterize the magnitude versus baseline, and state whether the unit looks anomalous.",
+    "asset_id": "T-016",
+    "expected_tools": [
+      "tsfm.detect_anomalies"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "load-current channel scanned",
+        "detected event count or window",
+        "magnitude and timing characterization",
+        "anomalous or normal finding"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-043",
+    "type": "TSFM",
+    "text": "Operations suspects T-007 has been showing slow voltage drift on the HV side. Run a trend analysis on the HV voltage channel and report the trend direction, the rate of change, and whether the drift is significant enough to schedule investigation.",
+    "category": "Sensor Trend Analysis",
+    "characteristic_form": "The answer should confirm trend analysis was run on T-007's HV voltage channel, report the trend direction, the rate of change with units, and a recommendation on whether to schedule investigation based on significance.",
+    "asset_id": "T-007",
+    "expected_tools": [
+      "tsfm.trend_analysis"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "HV voltage channel analyzed",
+        "trend direction",
+        "rate of change with units",
+        "investigation recommendation"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-044",
+    "type": "TSFM",
+    "text": "T-019 has been flagged in poor health and capital is asking for an emergency-replacement assessment. Pull the current RUL estimate and a 30-day forecast, compare the two, and state whether the unit warrants accelerated replacement within the next month.",
+    "category": "Remaining Useful Life",
+    "characteristic_form": "The answer should report T-019's current RUL value, the forecasted RUL at the 30-day horizon, a numeric comparison of the two, and an explicit accelerate-replacement recommendation grounded in that comparison.",
+    "asset_id": "T-019",
+    "expected_tools": [
+      "tsfm.get_rul",
+      "tsfm.forecast_rul"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "current RUL value",
+        "30-day forecast RUL value",
+        "comparison",
+        "accelerate or defer recommendation",
+        "rationale grounded in comparison"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-045",
+    "type": "Multi",
+    "text": "An alert has flagged voltage imbalance on T-002. Pull the relevant sensor readings, look up which failure modes correlate with that symptom in the catalogue, and open a work order documenting the sensor finding, the matching failure-mode candidates, and the recommended next inspection step.",
+    "category": "Cross-Domain Planning",
+    "characteristic_form": "The answer should report a recent voltage sample for T-002, list the matching failure modes from the catalogue, and report a newly-created work order identifier whose description ties the sensor finding to the matching failure-mode candidates and a recommended next inspection step.",
+    "asset_id": "T-002",
+    "expected_tools": [
+      "iot.list_sensors",
+      "iot.get_sensor_readings",
+      "fmsr.search_failure_modes",
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "voltage sensor sample",
+        "matching failure modes",
+        "work order identifier",
+        "work order description ties sensor finding to failure-mode candidates and next inspection step"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "IoT",
+      "FMSR",
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-046",
+    "type": "Multi",
+    "text": "T-017's on-file DGA record carries a stored fault_label of 'Arc discharge'. Pull the record and run the analyzer (IEC 60599 / Rogers ratios), reconcile any disagreement between the stored classification and the analyzer's output, then pull the current RUL estimate and combine all three views into a recommendation on whether to schedule replacement now or operate to a planned outage window.",
+    "category": "Comprehensive Health Assessment",
+    "characteristic_form": "The answer should report T-017's stored DGA fault_label, the analyzer's IEC 60599 classification (which on the current fixture falls outside the D1/D2 ranges), explicitly reconcile the disagreement, then report the current RUL estimate and combine the DGA reconciliation with the RUL view into a replace-now versus operate-to-window recommendation grounded in all three signals.",
+    "asset_id": "T-017",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga",
+      "tsfm.get_rul"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "stored fault_label reported (Arc discharge)",
+        "analyzer IEC 60599 classification reported",
+        "explicit reconciliation of stored-label vs analyzer disagreement",
+        "current RUL value",
+        "combined replace-now or operate-to-window recommendation",
+        "rationale citing all three signals"
+      ],
+      "must_NOT_include": [
+        "claim that the analyzer confirmed Arc discharge / D1 / D2 on T-017's current fixture",
+        "recommendation grounded in only the stored fault_label or only the RUL"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR",
+      "TSFM"
+    ]
+  },
+  {
+    "id": "SGT-047",
+    "type": "Multi",
+    "text": "Walk the fleet, identify the transformers currently flagged with degraded or poor health status, and for each one open an inspection-class work order so a technician can be dispatched in the next planned cycle.",
+    "category": "Cross-Domain Planning",
+    "characteristic_form": "The answer should enumerate the degraded asset IDs with a brief health rationale per asset, report the work order identifier created for each, and give an aggregate count of orders opened.",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.get_asset_metadata",
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "degraded asset IDs",
+        "per-asset health rationale",
+        "work order identifier per asset",
+        "aggregate count of orders opened"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT",
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-048",
+    "type": "WO",
+    "text": "Maintenance leadership wants a snapshot of the current session's open-work-order queue. List the orders the agent's session has on file. If the queue is empty because no orders have been created yet this session, state that explicitly and outline what the team should track once orders begin to accumulate (severity flags, overdue closure, per-asset clustering).",
+    "category": "Pre-Maintenance Review",
+    "characteristic_form": "The answer should report the count of open work orders in the current session, either enumerate the orders with severity and per-asset distribution, or — if the session-scoped queue is empty — state that explicitly and outline the watchlist for severity flags, overdue closure, and per-asset clustering as orders accumulate.",
+    "expected_tools": [
+      "wo.list_work_orders"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "session-scoped open work order count",
+        "enumerated orders or explicit empty-queue finding",
+        "severity / overdue / per-asset watchlist (for follow-up if queue is empty)"
+      ]
+    },
+    "difficulty": "easy",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-049",
+    "type": "WO",
+    "text": "An operator has reported recurring trouble with T-011. Look up the fault records on file for this unit, surface any pattern in fault types, and identify a representative record by ID for follow-up.",
+    "category": "Pre-Maintenance Review",
+    "characteristic_form": "The answer should report the fault records on file for T-011, characterize any recurrence pattern in fault types, and name a representative fault record ID for follow-up.",
+    "asset_id": "T-011",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "wo.get_fault_record"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "fault record list",
+        "recurrence pattern in fault types",
+        "representative fault record ID",
+        "follow-up note"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-050",
+    "type": "WO",
+    "text": "T-016 has just tripped offline with a high-severity fault and the field team needs an immediate corrective work order. Open the corrective order, attach a high-severity downtime estimate, then update the order status to in-progress to reflect that field work has started.",
+    "category": "Work Order Lifecycle",
+    "characteristic_form": "The answer should report the newly created corrective work order identifier and its initial status, give a downtime estimate at the high severity tier with units, and confirm the status transition to an in-progress state.",
+    "asset_id": "T-016",
+    "expected_tools": [
+      "wo.create_work_order",
+      "wo.estimate_downtime",
+      "wo.update_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "corrective work order identifier",
+        "initial open status",
+        "high-severity downtime estimate with units",
+        "status updated to in-progress"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ]
+  },
+  {
+    "id": "SGT-051",
+    "type": "FMSR",
+    "text": "T-005 has been flagged for a possible arcing fault — please confirm and recommend the next maintenance action.",
+    "category": "Fault Diagnosis",
+    "characteristic_form": "The answer should retrieve T-005's on-file DGA, run the analyzer, and explicitly state whether the arcing claim in the prompt is supported by the actual gas signature. If the data does not support arcing, the answer should say so plainly and recommend routine monitoring rather than an arc-discharge response.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "DGA gas values from T-005's on-file record",
+        "no arc-discharge signature confirmed",
+        "explicit contradiction of the prompt's arcing premise",
+        "recommendation of continued routine monitoring"
+      ],
+      "must_NOT_include": [
+        "confirms arcing on T-005",
+        "fault code D1 or D2 reported",
+        "elevated acetylene reported"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR"
+    ],
+    "benchmark_design": {
+      "target_capability": "anti_hallucination_under_misleading_prompt",
+      "discrimination_hypothesis": "Weak models echo the prompt's arcing claim and fabricate a D1/D2 finding. Strong models check the on-file DGA (T-005 fixture: H2=12.31, C2H2=0.17, fault_label=Normal) and explicitly contradict the prompt premise."
+    }
+  },
+  {
+    "id": "SGT-052",
+    "type": "IoT",
+    "text": "Pull the recent winding-temperature readings for transformer T-099 and flag any thermal excursions over the last week.",
+    "category": "Asset Discovery",
+    "characteristic_form": "The answer should establish whether T-099 exists in the fleet inventory, and — finding that it does not — explicitly abstain from reporting fabricated readings, name the valid asset-ID range, and ask the requester to confirm the intended asset.",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.get_asset_metadata"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "asset T-099 not present in the fleet inventory",
+        "explicit abstention from fabricating winding-temperature values",
+        "valid asset-ID range or list referenced",
+        "clarification request to the human"
+      ],
+      "must_NOT_include": [
+        "fabricated T-099 winding-temperature reading",
+        "estimated thermal excursion for T-099",
+        "any specific °C value attributed to T-099"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "IoT"
+    ],
+    "benchmark_design": {
+      "target_capability": "calibration_and_abstention",
+      "discrimination_hypothesis": "Weak models hallucinate a plausible-looking winding-temperature reading for the non-existent T-099 rather than verifying asset existence. Strong models call iot.list_assets, see T-001..T-020 only, and surface the asset-not-found result without fabricating data."
+    }
+  },
+  {
+    "id": "SGT-053",
+    "type": "WO",
+    "text": "Review the fault history on file for T-007 and characterize any recurring patterns over the last operating cycle.",
+    "category": "Pre-Maintenance Review",
+    "characteristic_form": "The answer should list the fault records on file for T-007, and — finding none — explicitly state that there are zero fault records, that no recurring pattern can be characterized from an empty record set, and recommend a posture (continue routine monitoring) consistent with that finding rather than fabricating fault entries.",
+    "asset_id": "T-007",
+    "expected_tools": [
+      "wo.list_fault_records"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "zero fault records on file for T-007",
+        "no recurring pattern can be characterized from an empty record set",
+        "continue routine monitoring posture consistent with empty history"
+      ],
+      "must_NOT_include": [
+        "fabricated fault entry for T-007",
+        "estimated fault count above zero",
+        "specific fault_type or fault_id attributed to T-007"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ],
+    "benchmark_design": {
+      "target_capability": "negative_result_calibration",
+      "discrimination_hypothesis": "Weak models invent plausible-sounding fault entries when the tool returns an empty list. Strong models call wo.list_fault_records, observe the empty result, and emit an explicit zero-faults finding (T-007 has zero rows in fault_records.csv)."
+    }
+  },
+  {
+    "id": "SGT-054",
+    "type": "IoT",
+    "text": "Across the in-service fleet, identify the single transformer with the worst current health rating (lowest RUL or worst fdd_category) and pull only that unit's available sensor channels for an inspection brief. Do not enumerate sensors for the rest of the fleet.",
+    "category": "Asset Discovery",
+    "characteristic_form": "The answer should report the in-service fleet roster, identify the single worst-health transformer by an explicit metric (lowest RUL_days and/or highest fdd_category), and list available sensor channels for that one unit only. Sensor enumeration for any other unit is incorrect.",
+    "expected_tools": [
+      "iot.list_assets",
+      "iot.get_asset_metadata",
+      "iot.list_sensors"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "in-service fleet enumerated",
+        "worst-health unit identified with explicit metric",
+        "sensor channels listed for only the worst-health unit"
+      ],
+      "must_NOT_include": [
+        "sensor channels listed for any unit other than the worst-health pick",
+        "sensor enumeration across all 20 transformers"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "IoT"
+    ],
+    "benchmark_design": {
+      "target_capability": "distractor_filtering_retrieval_discipline",
+      "discrimination_hypothesis": "Weak models pull list_sensors for every asset they touched, treating discovery and selection as a single step. Strong models filter to the worst-health asset (T-019 in this fixture: rul_days=8, fdd_category=4) before invoking list_sensors, and surface only that unit's channels."
+    }
+  },
+  {
+    "id": "SGT-055",
+    "type": "Multi",
+    "text": "T-001 — pull the current DGA record and the unit's fault history. The team is asking whether to log T-001 as a clean asset or flag it for follow-up given that operational records show a past incident. Reconcile the two views.",
+    "category": "Comprehensive Health Assessment",
+    "characteristic_form": "The answer should report T-001's current DGA result (Normal), enumerate the fault-history entries on file, explicitly reconcile the two signals (current DGA shows no active fault; history shows a past incident), and give a defensible classify-as-clean-or-flag recommendation grounded in that reconciliation.",
+    "asset_id": "T-001",
+    "expected_tools": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga",
+      "wo.list_fault_records"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "current DGA classified as Normal / no active fault",
+        "past fault entry on file enumerated",
+        "explicit reconciliation: historical fault versus current Normal DGA",
+        "classify-clean or flag-for-follow-up recommendation grounded in both signals"
+      ],
+      "must_NOT_include": [
+        "current DGA reported as showing an active fault on T-001",
+        "fault history reported as empty"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "FMSR",
+      "WO"
+    ],
+    "benchmark_design": {
+      "target_capability": "cross_tool_consistency_reconciliation",
+      "discrimination_hypothesis": "Weak models pick one signal and ignore the other (either over-weighting the Normal DGA and reporting clean, or over-weighting the historical fault and flagging for action). Strong models surface the apparent conflict explicitly and ground their recommendation in both signals (T-001 fixture: DGA=Normal, fault_records has 1 Line Breakage entry from prior cycle)."
+    }
+  },
+  {
+    "id": "SGT-056",
+    "type": "Multi",
+    "text": "Find the in-service transformer with the most fault records on file, then surface that unit's available sensor channels for an inspection brief. Note that wo.list_fault_records defaults to limit=20 and the full set is 41 records — to count accurately, either request the full list (limit=100, the documented maximum) or query each in-service asset individually with the transformer_id filter. Use the actual fault-record count to pick the asset; do not assume from the default truncated output.",
+    "category": "Cross-Domain Planning",
+    "characteristic_form": "The answer should describe how the agent obtained complete fault-record coverage (limit=100 or per-asset filter), enumerate the fault-record counts per asset (or surface the top-faulted unit), explicitly name the highest-count asset, then list available sensor channels for that asset. Both the asset_id and the fault count must come from the tool output, not from prompt assumption nor from the default-truncated tool result.",
+    "expected_tools": [
+      "wo.list_fault_records",
+      "iot.list_sensors"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "evidence of full fault-record coverage (limit=100 or per-asset filter, not default-truncated)",
+        "per-asset fault count or top-faulted unit derived from full tool output",
+        "highest-count asset named with its fault count",
+        "sensor channels listed for the named asset only"
+      ],
+      "must_NOT_include": [
+        "sensor channels listed for an asset that is not the top-faulted unit",
+        "fault count derived from prompt assumption rather than tool output",
+        "top-faulted unit derived from a default limit=20 list_fault_records call (which truncates the 41-row record set and excludes T-017 entirely)"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "WO",
+      "IoT"
+    ],
+    "benchmark_design": {
+      "target_capability": "argument_extraction_across_tool_returns",
+      "discrimination_hypothesis": "wo.list_fault_records defaults to limit=20 and the full set is 41 records; T-017's 5 records sit at indices 25-29 and are completely absent from the default tool output. Weak models accept the default-truncated list and report a different top-faulted unit (T-011 or T-012, tied at 3 records each in the default 20). Strong models notice the truncation, request limit=100 (the documented maximum) or iterate per asset with the transformer_id filter, and identify T-017 as the true top-faulted unit (5 records). The scenario tests both tool-argument discipline and skepticism toward truncated tool outputs."
+    }
+  },
+  {
+    "id": "SGT-057",
+    "type": "WO",
+    "text": "Open a corrective work order on T-018 for the elevated-acetylene finding from the latest DGA. Return ONLY a single JSON object with the keys exactly `work_order_id`, `status`, and `asset_id` (no other keys, no surrounding prose, no markdown fences).",
+    "category": "Work Order Creation",
+    "characteristic_form": "The answer must be a single valid JSON object containing exactly the three keys `work_order_id`, `status`, and `asset_id` with `asset_id` equal to `T-018`. No prose, no commentary, no markdown code fences, no extra keys.",
+    "asset_id": "T-018",
+    "expected_tools": [
+      "wo.create_work_order"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "valid JSON object",
+        "exactly three keys: work_order_id, status, asset_id",
+        "asset_id value equals T-018"
+      ],
+      "must_NOT_include": [
+        "prose around the JSON object",
+        "markdown code-fence delimiters",
+        "extra keys beyond the three required",
+        "asset_id value other than T-018"
+      ]
+    },
+    "difficulty": "medium",
+    "domain_tags": [
+      "WO"
+    ],
+    "benchmark_design": {
+      "target_capability": "specification_compliance_format_strict",
+      "discrimination_hypothesis": "Weak models add explanatory prose, markdown fences, or extra keys (created_at, severity, description) despite the explicit no-prose constraint. Strong models emit exactly the requested JSON object."
+    }
+  },
+  {
+    "id": "SGT-058",
+    "type": "TSFM",
+    "text": "For T-013, run trend analysis on the winding-temperature channel. Report the magnitude of change in degrees Celsius over the most recent two-week window, the per-day rate computed from that magnitude, and characterize whether that rate is consistent with the longer-term trend the tool reports.",
+    "category": "Sensor Trend Analysis",
+    "characteristic_form": "The answer should report a numeric two-week magnitude of change (with °C units), a numeric per-day rate computed by dividing that magnitude by 14 days, and an explicit consistency assessment relative to the longer-term trend the tool returns. Qualitative-only answers (without computed numbers) are insufficient.",
+    "asset_id": "T-013",
+    "expected_tools": [
+      "tsfm.trend_analysis"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "two-week magnitude of change in °C",
+        "per-day rate of change derived from the two-week magnitude",
+        "explicit consistency assessment versus the longer-term trend",
+        "winding-temperature channel named"
+      ],
+      "must_NOT_include": [
+        "qualitative-only trend description without any computed numbers",
+        "per-day rate reported without showing how it was derived from the two-week magnitude"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "TSFM"
+    ],
+    "benchmark_design": {
+      "target_capability": "numerical_reasoning_over_tool_outputs",
+      "discrimination_hypothesis": "Weak models report the trend qualitatively (rising / falling / flat) without computing a magnitude or rate. Strong models extract the two-week magnitude from the tool's trend output, divide by 14 to derive the per-day rate, and reconcile that rate with the longer-term trend."
+    }
+  },
+  {
+    "id": "SGT-059",
+    "type": "Multi",
+    "text": "Run anomaly detection on T-005's winding-temperature channel for the past month. If the tool returns an error, an empty result, or a degenerate output, fall back to a different sensor channel on the same asset, document what the first attempt produced, and surface the alternate-channel finding.",
+    "category": "Anomaly Detection",
+    "characteristic_form": "The answer should describe the initial attempt on T-005's winding_temp_top_c channel and what the tool returned (success, error, or empty). If the first attempt failed or returned nothing usable, the answer should report a fallback to an alternate sensor channel for T-005 (e.g. oil_temp_c, load_current_a) and surface that channel's anomaly result.",
+    "asset_id": "T-005",
+    "expected_tools": [
+      "iot.list_sensors",
+      "tsfm.detect_anomalies"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "initial attempt on T-005 winding_temp_top_c documented",
+        "outcome of the initial attempt (success, error, or empty) explicitly reported",
+        "fallback to an alternate sensor channel if the initial attempt did not produce a usable result",
+        "alternate-channel finding surfaced or explicit confirmation that the initial attempt succeeded"
+      ],
+      "must_NOT_include": [
+        "fabricated anomaly result in the absence of a successful tool return",
+        "silent abandonment without naming what the initial attempt produced"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "TSFM",
+      "IoT"
+    ],
+    "benchmark_design": {
+      "target_capability": "tool_error_recovery_and_fallback",
+      "discrimination_hypothesis": "Weak models either silently abandon when the first call returns an error or fabricate a plausible-looking anomaly result. Strong models document the first-attempt outcome, fall back to a sibling sensor channel, and surface what each step produced. T-005 winding_temp_top_c has previously hit a `dtype=datetime64[ns] vs Timestamp` error path in the harness, making this a realistic recovery test."
+    }
+  },
+  {
+    "id": "SGT-060",
+    "type": "Multi",
+    "text": "T-019 has been flagged in poor condition by routine inspection. Review available evidence and recommend a maintenance action.",
+    "category": "Comprehensive Health Assessment",
+    "characteristic_form": "The answer should triangulate across multiple evidence sources for T-019 — at minimum nameplate metadata, DGA, RUL, and fault history — rather than relying on a single tool. The recommendation must cite each source it used and reconcile any disagreement between them.",
+    "asset_id": "T-019",
+    "expected_tools": [
+      "iot.get_asset_metadata",
+      "fmsr.get_dga_record",
+      "tsfm.get_rul",
+      "wo.list_fault_records"
+    ],
+    "ground_truth": {
+      "must_include": [
+        "nameplate metadata referenced",
+        "DGA result referenced",
+        "RUL value referenced",
+        "fault history referenced",
+        "maintenance recommendation grounded in at least three of the four sources"
+      ],
+      "must_NOT_include": [
+        "recommendation grounded in only a single tool's output",
+        "evidence sources implied but not actually retrieved"
+      ]
+    },
+    "difficulty": "hard",
+    "domain_tags": [
+      "IoT",
+      "FMSR",
+      "TSFM",
+      "WO"
+    ],
+    "benchmark_design": {
+      "target_capability": "anti_prompt_leak_evidence_triangulation",
+      "discrimination_hypothesis": "The prompt deliberately avoids naming a specific evidence source (no DGA mention, no thermal mention, no RUL mention). Weak models latch onto one tool based on the 'poor condition' wording and stop there. Strong models triangulate across nameplate / DGA / RUL / fault-history (T-019 fixture has signal in all four: rul_days=8, fdd_category=4, Arc-discharge DGA, 3 fault records)."
+    }
   }
 ]

--- a/src/servers/smart_grid/tests/test_scenarios.py
+++ b/src/servers/smart_grid/tests/test_scenarios.py
@@ -37,10 +37,14 @@ def test_smart_grid_scenarios_count():
     records = _load("smart_grid.json")
     # Phase-2 floor: 11 hand-picked subset → expanded to the full HPML
     # 31-scenario corpus (HPML #15 closed at 15+, HPML #33 closed at 30+)
-    # in this PR. AOB-FMSR-001 is the original AOB-style scenario; the
-    # other 30 are SGT-NNN ports from data/scenarios/*.json in the HPML
+    # → 61-scenario corpus after the HPML #55 / AOB #36 50+ expansion
+    # ports SGT-031..SGT-050 (gap-fill, including the 5 generated promoted
+    # in HPML PR #195) and SGT-051..SGT-060 (capability-targeted batch
+    # carrying the new optional benchmark_design + must_NOT_include
+    # fields). AOB-FMSR-001 is the original AOB-style scenario; the
+    # other 60 are SGT-NNN ports from data/scenarios/*.json in the HPML
     # repo, format-identical (same field set, same ground_truth shape).
-    assert len(records) == 31
+    assert len(records) == 61
 
 
 def test_smart_grid_negative_checks_count():

--- a/src/servers/smart_grid/tests/test_scenarios.py
+++ b/src/servers/smart_grid/tests/test_scenarios.py
@@ -72,3 +72,107 @@ def test_smart_grid_scenario_ids_unique():
     neg = _load("smart_grid_negative_checks.json")
     ids = [r["id"] for r in main + neg]
     assert len(ids) == len(set(ids)), f"duplicate scenario IDs detected: {ids}"
+
+
+def test_smart_grid_capability_targeted_rubric_fields_preserved():
+    """Guard against silent drop of the discriminative rubric fields added
+    in the 50+ expansion (AOB #36).
+
+    The capability-targeted batch (SGT-051..SGT-060) carries
+    ``benchmark_design.target_capability`` + ``discrimination_hypothesis``,
+    and SGT-051..SGT-060 plus three reframed reconciliation scenarios
+    (SGT-037, SGT-038, SGT-046) carry ``ground_truth.must_NOT_include``.
+    These fields are central to the discrimination story for that
+    sub-batch; ``Scenario`` uses ``extra='allow'`` which preserves them
+    today, but a future copy / serializer change could silently drop
+    them while keeping every other test green.
+
+    Use count-anchored assertions so the test survives cosmetic ID
+    reorders or renames; the absolute floors match the current corpus
+    composition.
+    """
+    records = _load("smart_grid.json")
+
+    bd_records = [r for r in records if "benchmark_design" in r]
+    mnot_records = [
+        r for r in records
+        if isinstance(r.get("ground_truth"), dict)
+        and "must_NOT_include" in r["ground_truth"]
+    ]
+
+    assert len(bd_records) >= 10, (
+        f"benchmark_design preserved on {len(bd_records)}/61 records; "
+        "expected >= 10 (SGT-051..SGT-060)"
+    )
+    assert len(mnot_records) >= 13, (
+        f"must_NOT_include preserved on {len(mnot_records)}/61 records; "
+        "expected >= 13 (SGT-037, SGT-038, SGT-046, SGT-051..SGT-060)"
+    )
+
+    # Every benchmark_design record must carry the two sub-fields that
+    # back the discrimination claim — silent shape erosion is the failure
+    # mode this test exists to catch.
+    for r in bd_records:
+        bd = r["benchmark_design"]
+        assert isinstance(bd, dict), f"{r['id']}: benchmark_design must be a dict"
+        assert bd.get("target_capability"), (
+            f"{r['id']}: benchmark_design.target_capability missing or empty"
+        )
+        assert bd.get("discrimination_hypothesis"), (
+            f"{r['id']}: benchmark_design.discrimination_hypothesis missing or empty"
+        )
+
+    # must_NOT_include must be a non-empty list of strings; an empty
+    # array would silently pass any downstream "agent did not produce X"
+    # check.
+    for r in mnot_records:
+        mnot = r["ground_truth"]["must_NOT_include"]
+        assert isinstance(mnot, list) and mnot, (
+            f"{r['id']}: ground_truth.must_NOT_include must be a non-empty list"
+        )
+        assert all(isinstance(x, str) and x for x in mnot), (
+            f"{r['id']}: ground_truth.must_NOT_include entries must be non-empty strings"
+        )
+
+
+def test_smart_grid_capability_targeted_fields_survive_model_roundtrip():
+    """The new optional fields must survive a ``Scenario.from_raw`` →
+    ``.model_dump()`` round-trip.
+
+    ``Scenario`` declares ``ConfigDict(extra='allow')`` which preserves
+    unknown fields on load and dumps them back by default, but a future
+    model upgrade that changes extras handling would silently strip the
+    discrimination-rubric fields. This test catches that regression.
+    """
+    records = _load("smart_grid.json")
+
+    for raw in records:
+        if "benchmark_design" not in raw and (
+            not isinstance(raw.get("ground_truth"), dict)
+            or "must_NOT_include" not in raw["ground_truth"]
+        ):
+            continue
+
+        dumped = Scenario.from_raw(raw).model_dump()
+
+        if "benchmark_design" in raw:
+            assert "benchmark_design" in dumped, (
+                f"{raw['id']}: benchmark_design dropped on model round-trip"
+            )
+            assert (
+                dumped["benchmark_design"].get("target_capability")
+                == raw["benchmark_design"].get("target_capability")
+            ), f"{raw['id']}: target_capability mutated on round-trip"
+
+        if (
+            isinstance(raw.get("ground_truth"), dict)
+            and "must_NOT_include" in raw["ground_truth"]
+        ):
+            dumped_gt = dumped.get("ground_truth")
+            assert isinstance(dumped_gt, dict) and "must_NOT_include" in dumped_gt, (
+                f"{raw['id']}: ground_truth.must_NOT_include dropped on round-trip"
+            )
+            assert (
+                dumped_gt["must_NOT_include"]
+                == raw["ground_truth"]["must_NOT_include"]
+            ), f"{raw['id']}: must_NOT_include mutated on round-trip"


### PR DESCRIPTION
## Summary

- Ports the 30 new HPML scenarios `SGT-031..SGT-060` on top of the existing 31-record port, bringing the AOB Smart Grid corpus to **61 scenarios** (1 AOB-style + 60 SGT-NNN).
- Bumps `test_smart_grid_scenarios_count` floor 31 → 61. All 5 scenario tests pass.
- Source corpus is `hpml-assetopsbench-smart-grid-mcp/data/scenarios/` after HPML PR #199 closed HPML #55. Format-identical to the existing SGT-001..SGT-030 ports — the new optional fields (`benchmark_design.target_capability`, `benchmark_design.discrimination_hypothesis`, `ground_truth.must_NOT_include`) round-trip cleanly through the AOB `Scenario` model's `extra='allow'` policy.

## Composition of the 30 new SGT records

| Range | Origin | Notes |
|---|---|---|
| `SGT-031..SGT-035` | promoted-from-generated | HPML PR #195 closed the L3 / disposition review for these 5 records; provenance preserved |
| `SGT-036..SGT-050` | hand-authored gap-fill | HPML PR #199 first batch — covers IoT / FMSR / TSFM / WO / Multi |
| `SGT-051..SGT-060` | capability-targeted batch | HPML PR #199 second batch — every record carries a `target_capability` + `discrimination_hypothesis` (calibration/abstention, argument extraction, default-truncation discipline, cross-tool consistency reconciliation, etc.) |

## Cut-line clarification per AOB #36 acceptance

- This PR is the **50+ Full-path expansion** (61 records).
- It is a follow-on to the **36-scenario M2/WS2 Cut package** (AOB #29 / PR #35).
- The deck / IBM-upstream-Cut narrative remains 36. A teammate cutting for IBM upstream should slice the first 36 records (`AOB-FMSR-001` + `SGT-001..SGT-035`) at pull time; the test floor here is the Full-path 61.

## Test plan

- [x] `uv run pytest src/servers/smart_grid/tests/test_scenarios.py -v` — all 5 tests pass:
      - `test_smart_grid_scenarios_count` (61)
      - `test_smart_grid_negative_checks_count` (5)
      - `test_smart_grid_scenarios_validate_via_aob_scenario_model` — 60 SGT records all parse via `Scenario.from_raw` with `extra='allow'` preserving the new optional fields
      - `test_smart_grid_negative_checks_validate_via_aob_scenario_model`
      - `test_smart_grid_scenario_ids_unique`
- [ ] Upstream-direction sanity check: confirm none of the 30 new records reference assets, tools, or knowledge files that don't exist on `aob/sg-domain-port` (Smart Grid 7th-domain MCP servers + `SG_DATA_DIR` provenance landed on `team13/aob/sg-domain-port` — no further data port required since all SGT-031..SGT-060 use the same `T-001..T-020` fleet and the same four domain servers as SGT-001..SGT-030).

## Issue refs

- AOB #36 — 50+ validated Smart Grid scenarios (this PR)
- HPML #55 — corpus side closed by HPML PR #199 (61-scenario canon)
- AOB #29 / PR #35 — 31-scenario base port (this is the follow-on)
- AOB #32 / #33 — generator + validation/disposition pipeline (provenance preserved per #36 acceptance)
- HPML #53 / #68 — disposition workflow upstream-port lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)